### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [ master ]
 
+permissions:
+  contents: read
+
 jobs:
   test:
     name: Test


### PR DESCRIPTION
Potential fix for [https://github.com/valentineus/go-metatrader4/security/code-scanning/1](https://github.com/valentineus/go-metatrader4/security/code-scanning/1)

To fix the issue, we need to add a `permissions` block to the workflow file. This block should specify the minimal permissions required for the workflow to function correctly. Since the workflow only reads repository contents and does not perform any write operations, the `contents: read` permission is sufficient. The `permissions` block can be added at the root level of the workflow to apply to all jobs, or it can be added to each job individually.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
